### PR TITLE
Remove iOS-only filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ fastlane/test_output
 iOSInjectionProject/
 
 bazel-*
+.DS_Store

--- a/Sources/SignHereLibrary/Services/iTunesConnectService.swift
+++ b/Sources/SignHereLibrary/Services/iTunesConnectService.swift
@@ -280,8 +280,8 @@ internal class iTunesConnectServiceImp: iTunesConnectService {
         do {
             let listBundleIDsResponse: ListBundleIDsResponse = try createITCApiJSONDecoder().decode(ListBundleIDsResponse.self, from: data)
             guard let bundleIdITCId: String = listBundleIDsResponse.data.compactMap({ bundleData in
-                guard bundleData.attributes.identifier == bundleIdentifier,
-                    bundleData.attributes.platform == "IOS"                              //same here, is this only for ios? 
+                guard bundleData.attributes.identifier == bundleIdentifier
+                //     bundleData.attributes.platform == "IOS" 
                 else {
                     return nil
                 }

--- a/Sources/SignHereLibrary/Services/iTunesConnectService.swift
+++ b/Sources/SignHereLibrary/Services/iTunesConnectService.swift
@@ -281,7 +281,6 @@ internal class iTunesConnectServiceImp: iTunesConnectService {
             let listBundleIDsResponse: ListBundleIDsResponse = try createITCApiJSONDecoder().decode(ListBundleIDsResponse.self, from: data)
             guard let bundleIdITCId: String = listBundleIDsResponse.data.compactMap({ bundleData in
                 guard bundleData.attributes.identifier == bundleIdentifier
-                //     bundleData.attributes.platform == "IOS" 
                 else {
                     return nil
                 }


### PR DESCRIPTION
Many of our bundle ID are `UNIVERSAL`. Removing this check allows them to work.

I have verified all our bundle IDs return the appropriate files now.